### PR TITLE
[cicd] Delete files from previous deploy.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,9 @@ jobs:
         pwd
         pushd "${DEPLOY_REPO_CHECKOUT_PATH}"
         mkdir -p "${DEPLOY_AUTOCOMMIT_PATHSPEC}"
+        # If existing content, delete existing content from previous commit and
+        # keep nist-pages branch clean in the deploy subdirectory.
+        rm -rf "${DEPLOY_AUTOCOMMIT_PATHSPEC}/*"
         popd
         pushd "${MAIN_REPO_CHECKOUT_PATH}"
         ls -lha
@@ -127,5 +130,5 @@ jobs:
         branch: ${{ env.DEPLOY_REPO_GIT_REF }}
         file_pattern: '${{ env.DEPLOY_AUTOCOMMIT_PATHSPEC }}'
         skip_dirty_check: false
-        commit_message: Pushing generated oscal-tool website pages [ci skip]
+        commit_message: Pushing generated oscal-cat application [ci skip]
       id: finalize-deployment

--- a/OSCAL-CAT-App/src/index.html
+++ b/OSCAL-CAT-App/src/index.html
@@ -29,7 +29,7 @@
   <app-root></app-root>
 
 
-  <noscript>Please enable JavaScript. OSCAL-CAT App is a JavaScript-based application.</noscript>
+  <noscript>Please enable JavaScript. OSCAL-CAT App requires JavaScript.</noscript>
 </body>
 
 </html>


### PR DESCRIPTION
During review of usnistgov/oscal-cat#19, it was recommended even if Angular does tree
shaking and file and path optimization for the app code and additional assets, we
delete contents from the previous deploy to pages.nist.gov/oscal-tools in the subdir
of usnistgov/oscal-tools repo nist-pages branch accordingly.